### PR TITLE
throw a type error if values only

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = partial
 function partial(fn) {
     var args = copyOver(arguments, 1)
     var firstArg = args[0]
-    var hasObjects = false
+    var hasObjects = args.length === 0
     var key
 
     if (typeof firstArg === "object" && firstArg !== null) {


### PR DESCRIPTION
`mercury.partial()` cannot cache effectively on an array containing only values.

i.e. `[true, false, 'foobar', 42]` is not something which we can apply the `partial` thunk caching technique too without edge cases.
