### PR TITLE
Clarify thunk and linked to virtual-dom doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 
 A thunk optimization for virtual-dom
 
+For an introduction on **Thunk interface** in general, see
+  [virtual-dom doc](https://github.com/Matt-Esch/virtual-dom/blob/master/docs/thunk.md).
+
 ## Example
 
 Use Thunk when you want to avoid re-rendering subtrees.


### PR DESCRIPTION
This is a small step towards a better doc, which IMHO is a bit confusing to new users due to its overloading use of `Thunk`, which can mean either:
1. `vdom-thunk` itself, as in `var thunk = Thunk(fn, ...args)`
2. what `partial` returns, as in `var Thunk = partial(eqFunc)`
3. An implementation of _Thunk interface_, ie. `ImmutableThunk`

Better to let users know upfront about Thunk interface, then the rest is easier to digest.
